### PR TITLE
Fixes #13: Suppression de Spring Data REST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
-        </dependency>
+        
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,4 +6,4 @@ spring.datasource.password=smart
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.database=postgresql
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary by Sourcery

Remove the Spring Data REST dependency and associated configurations.

Enhancements:
- Remove the `spring-boot-starter-data-rest` dependency from the project build configuration.
- Remove the `spring.jpa.hibernate.ddl-auto=create-drop` property from application properties.